### PR TITLE
Exhaustive option

### DIFF
--- a/umap2/apps/vsscan.py
+++ b/umap2/apps/vsscan.py
@@ -97,6 +97,7 @@ class _ScanSession(object):
         self.db = []
         self.supported = []
         self.unsupported = []
+        self.supported_drivers = []
         # key: device that got no response
         # value: previous device (if any)
         self.no_response = {}
@@ -233,10 +234,11 @@ class Umap2VSScanApp(Umap2App):
             db_entry.os = self.os
             vid = db_entry.vid
             pid = db_entry.pid
-            driver = db_entry.drivers[self.os]
             if not self.options['--exhaustive']:
+                driver = db_entry.drivers.get(self.os, None)
                 if driver and driver in self.scan_session.supported_drivers:
-                    self.debug('skipping entry: %s' % db_entry)
+                    self.logger.always('skipping entry: %s' % db_entry)
+                    self.sync_and_increment_session()
                     continue
             self.logger.always('Testing support for %s' % db_entry)
             self.setup_packet_received = False

--- a/umap2/apps/vsscan.py
+++ b/umap2/apps/vsscan.py
@@ -256,7 +256,9 @@ class Umap2VSScanApp(Umap2App):
             if self.current_usb_function_supported:
                 db_entry.info = self.get_device_info(device)
                 self.scan_session.supported.append(db_entry)
-                self.scan_session.supported_drivers.append(db_entry.drivers[self.os])
+                driver = db_entry.drivers.get(self.os, None)
+                if driver:
+                    self.scan_session.supported_drivers.append(db_entry.drivers[self.os])
             else:
                 db_entry.info = self.get_device_info(device)
                 self.scan_session.unsupported.append(db_entry)


### PR DESCRIPTION
Added new feature - Exhaustive scan (default is off)
This feature will cause the Umap2vsscan to skip all entries whos driver has been found to be supported. The assumption is that if you found one vid,pid combo to get you 'access' to the driver code - there is really no need for you to test other vid,pid combos which have the same driver.
If this is not the case, use the -e option to scan all entries anyway.
NOTE: If the driver is not supported - all vid,pid combos will be tried. We are not skipping the other vid,pid combos - in case one would be able to detect response from the host.