### PR TITLE
Adding Raspberry Pi Zero W support :D

### DIFF
--- a/gadget/README.rst
+++ b/gadget/README.rst
@@ -54,7 +54,7 @@ we provide 2 versions of the patched inode.c (gadgetfs module source):
   - inode.c-v4.4.9 for kernel v4.4.9 which is widely used (at the time)
     for the BeagleBone black
   - inode.c-v4.6_and_up which should be compatible at least up to v4.8-rc5
-  - Raspberry Pi W works out of the box with kernel 4.12.0-rc3+, no patching needed
+  - Raspberry Pi W works out of the box with kernel 4.12.0-rc3+, no patching needed, just add "dtoverlay=dwc2" to /boot/config.txt and add " modules-load=dwc2 " after rootwait string in /boot/config.txt. For shell use UART cable with raspberry pi zero w gpio pins for shell.
 
 **Note:** Currently we assume that all operations are performed as root.
 
@@ -82,7 +82,7 @@ You can use the following script to do that:
 ::
 
   $ $UMAP2_HOME/gadget/start_gadgetfs.sh
-or for Raspberr Pi Zero W :
+or for Raspberry Pi Zero W :
   $ $UMAP2_HOME/gadget/start_gadgetfs_RaspiZeroW.sh
 
 Once the new module is loaded,

--- a/gadget/README.rst
+++ b/gadget/README.rst
@@ -27,7 +27,8 @@ it details the limitations and usage for Umap2 on such a device.
 
 Limitations
 -----------
-
+- For Raspberry Pi Zero W, only kernel 4.12.0-rc3+ and above seem to work stable, run
+  start_gadgetfs_RaspiZeroW.sh to mount gadgetfs. Patching kernel isn't needed.
 - Currently we only support **BeagleBone Black** with Robert C. Nelson's Linux
   kernel, you can clone it from it from `here <https://github.com/RobertCNelson/bb-kernel>`_
   and use the branch **am33x-v4.7**.
@@ -53,6 +54,7 @@ we provide 2 versions of the patched inode.c (gadgetfs module source):
   - inode.c-v4.4.9 for kernel v4.4.9 which is widely used (at the time)
     for the BeagleBone black
   - inode.c-v4.6_and_up which should be compatible at least up to v4.8-rc5
+  - Raspberry Pi W works out of the box with kernel 4.12.0-rc3+, no patching needed
 
 **Note:** Currently we assume that all operations are performed as root.
 
@@ -80,6 +82,8 @@ You can use the following script to do that:
 ::
 
   $ $UMAP2_HOME/gadget/start_gadgetfs.sh
+or for Raspberr Pi Zero W :
+  $ $UMAP2_HOME/gadget/start_gadgetfs_RaspiZeroW.sh
 
 Once the new module is loaded,
 you can run Umap2 as described in the README.rst in the root of the repository,

--- a/gadget/README.rst
+++ b/gadget/README.rst
@@ -54,7 +54,10 @@ we provide 2 versions of the patched inode.c (gadgetfs module source):
   - inode.c-v4.4.9 for kernel v4.4.9 which is widely used (at the time)
     for the BeagleBone black
   - inode.c-v4.6_and_up which should be compatible at least up to v4.8-rc5
-  - Raspberry Pi W works out of the box with kernel 4.12.0-rc3+, no patching needed, just add "dtoverlay=dwc2" to /boot/config.txt and add " modules-load=dwc2 " after rootwait string in /boot/config.txt. For shell use UART cable with raspberry pi zero w gpio pins for shell.
+  - Raspberry Pi W works out of the box with kernel 4.12.0-rc3+, no patching 
+    needed, just add "enable_uart=1" and "dtoverlay=dwc2" to /boot/config.txt 
+    and add " modules-load=dwc2 " after rootwait string in /boot/config.txt. 
+    For shell use UART cable with raspberry pi zero w gpio pins for shell.
 
 **Note:** Currently we assume that all operations are performed as root.
 

--- a/gadget/start_gadgetfs_RaspiZeroW.sh
+++ b/gadget/start_gadgetfs_RaspiZeroW.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+sudo modprobe gadgetfs
+sudo mkdir /dev/gadget
+sudo mount -t gadgetfs none /dev/gadget
+

--- a/gadget/start_gadgetfs_RaspiZeroW.sh
+++ b/gadget/start_gadgetfs_RaspiZeroW.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-sudo modprobe gadgetfs
-sudo mkdir /dev/gadget
-sudo mount -t gadgetfs none /dev/gadget
+modprobe gadgetfs
+mkdir /dev/gadget
+mount -t gadgetfs none /dev/gadget
 


### PR DESCRIPTION
As there were several issues with beaglebone black due to limited kernel stability, and due to the raspberry pi zero w being small and very flexible, I added support to Raspberry Pi Zero W.

So far, only kernel 4.12.0-rc3+ seems to work stable, previous kernel versions as 4.8 or 4.9 don't even with patching gadgetfs inode.c.
