### PR TITLE
A control filename added for Raspberry Pi Zero W

### DIFF
--- a/umap2/phy/gadgetfs/gadgetfs_phy.py
+++ b/umap2/phy/gadgetfs/gadgetfs_phy.py
@@ -99,6 +99,7 @@ class GadgetFsPhy(PhyInterface):
         'at91_udc',
         'lh740x_udc',
         'atmel_usba_udc',
+        '20980000.usb',
     ]
 
     def __init__(self, app, gadgetfs_dir='/dev/gadget'):


### PR DESCRIPTION
My raspberry pi zero w hardware is recognized as "/dev/20980000.usb" on Rasbian buster.
The device file name might be added.