### PR TITLE
A control name added for Rasp Pi 4B and fix a bug in dev/mass_storage.py

### DIFF
--- a/umap2/dev/mass_storage.py
+++ b/umap2/dev/mass_storage.py
@@ -207,7 +207,8 @@ class ScsiDevice(USBBaseActor):
                     resp = self.handlers[opcode](cbw)
                     if resp is not None:
                         self.tx.put(resp)
-                    self.tx.put(scsi_status(cbw, ScsiCmdStatus.COMMAND_PASSED))
+                    if opcode != ScsiCmds.WRITE_10:
+                        self.tx.put(scsi_status(cbw, ScsiCmdStatus.COMMAND_PASSED))
                 except Exception as ex:
                     self.warning('exception while processing opcode %#x' % (opcode))
                     self.warning(ex)

--- a/umap2/phy/gadgetfs/gadgetfs_phy.py
+++ b/umap2/phy/gadgetfs/gadgetfs_phy.py
@@ -100,6 +100,7 @@ class GadgetFsPhy(PhyInterface):
         'lh740x_udc',
         'atmel_usba_udc',
         '20980000.usb',
+        'fe980000.usb',
     ]
 
     def __init__(self, app, gadgetfs_dir='/dev/gadget'):


### PR DESCRIPTION
A control name "fe980000.usb" is added for Rasp Pi 4B gadgetfs.

There is a bug in dev/mass_storage.py. When ScsiDevice processes ScsiCmds.WRITE_10 request, it sends scsi_status twice. A scsi_status is sent in handle_data when handle_write_10 return, and another scsi_status is sent in handle_write_data. This bug causes a problem when you try to write the storage in ubuntu 18.04.